### PR TITLE
chore: small updates (Jekyll setup, logo/footer, URLs, content fixes)

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,23 +2,9 @@
 layout: default
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="container">
-  <h1>404</h1>
-
-  <p><strong>Page not found :(</strong></p>
+<div class="page-404 wrapper">
+  <h1 class="page-404-title">404</h1>
+  <p><strong>Page not found</strong></p>
   <p>The requested page could not be found.</p>
+  <p><a href="{{ '/' | relative_url }}">← Back to AIPs</a></p>
 </div>

--- a/AIPS/aip-1.md
+++ b/AIPS/aip-1.md
@@ -48,7 +48,7 @@ Vetting an idea publicly before going as far as writing an AIP is meant to save 
 
 Once the champion has asked the ADAMANT community whether an idea has any chance of acceptance a draft AIP should be presented as a [pull request].
 
-If the AIP editors approve the AIP ([see the AIP editors workflow section below for details](#eip-editor-responsibilities-and-workflow)) and the authors are happy for it to be merged as a draft, the AIP editor will assign the AIP a number and merge your pull request. The AIP editor will not unreasonably deny an AIP. (AIP authors can request for it to be merged after they have finished editing it, and editors can ask if they have finished editing it and would like it to be merged. This prevents merging an AIP when more edits are intended to be made by the author, although it can always be edited after merging.) Reasons for denying AIP status include duplication of effort, being technically unsound, not providing proper motivation or addressing backwards compatibility, or not in keeping with the ADAMANT philosophy.
+If the AIP editors approve the AIP ([see the AIP editors workflow section below for details](#aip-editor-responsibilities-and-workflow)) and the authors are happy for it to be merged as a draft, the AIP editor will assign the AIP a number and merge your pull request. The AIP editor will not unreasonably deny an AIP. (AIP authors can request for it to be merged after they have finished editing it, and editors can ask if they have finished editing it and would like it to be merged. This prevents merging an AIP when more edits are intended to be made by the author, although it can always be edited after merging.) Reasons for denying AIP status include duplication of effort, being technically unsound, not providing proper motivation or addressing backwards compatibility, or not in keeping with the ADAMANT philosophy.
 
 Once the first draft has been merged, you may submit follow-up pull requests with further changes to your draft until such point as you believe the AIP to be mature and ready to proceed to the next phase.
 
@@ -116,7 +116,7 @@ AIP Formats and Templates
 -------------------------
 
 AIPs should be written in [markdown] format.
-Image files should be included in a subdirectory of the `assets` folder for that AIP as follow: `assets/Aip-X` (for AIP **X**). When linking to an image in the AIP, use relative links such as `../assets/aip-X/image.png`.
+Image files should be included in a subdirectory of the `assets` folder for that AIP as follow: `assets/aip-X` (for AIP **X**). When linking to an image in the AIP, use relative links such as `../assets/aip-X/image.png`.
 
 AIP Header Preamble
 -------------------
@@ -220,7 +220,7 @@ Once the AIP is ready for the repository, the AIP editor will:
 
 - Send a message back to the AIP author with the next step.
 
-Many AIPs are written and maintained by developers with write access to the Ethereum codebase. The AIP editors monitor AIP changes, and correct any structure, grammar, spelling, or markup mistakes we see.
+Many AIPs are written and maintained by developers with write access to the ADAMANT codebase. The AIP editors monitor AIP changes, and correct any structure, grammar, spelling, or markup mistakes we see.
 
 The editors don't pass judgment on AIPs. We merely do the administrative & editorial part.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "jekyll", "~> 3.9"
+gem "jekyll-theme-minima"
+gem "jekyll-feed"
+gem "kramdown-parser-gfm"
+gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,213 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    csv (3.3.5)
+    drb (2.2.3)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    html-pipeline (2.14.3)
+      activesupport (>= 2)
+      nokogiri (>= 1.4)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.10.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (>= 0.7, < 2)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (>= 1.17, < 3)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+      webrick (>= 1.0)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-mentions (1.6.0)
+      html-pipeline (~> 2.3)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-theme-minima (0.1.1)
+      jekyll (~> 3.8)
+      jekyll-mentions
+      minima
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.18.1)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.3.6)
+    minima (2.5.2)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
+    minitest (6.0.1)
+      prism (~> 1.5)
+    nokogiri (1.19.0-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-musl)
+      racc (~> 1.4)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    prism (1.9.0)
+    public_suffix (7.0.2)
+    racc (1.8.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (3.30.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    securerandom (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.1.1)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 3.9)
+  jekyll-feed
+  jekyll-theme-minima
+  kramdown-parser-gfm
+  webrick
+
+CHECKSUMS
+  activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
+  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
+  eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
+  ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
+  ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
+  ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
+  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
+  ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
+  forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
+  html-pipeline (2.14.3) sha256=8a1d4d7128b2141913387cac0f8ba898bb6812557001acc0c2b46910f59413a0
+  http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  jekyll (3.10.0) sha256=c4213b761dc7dfe7d499eb742d0476a02d8503e440c2610e19774ee7f0db8d90
+  jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
+  jekyll-mentions (1.6.0) sha256=39e801024cb6f2319b3f78a29999d0068ef5f68bc5202b8757d5354fef311ed9
+  jekyll-sass-converter (1.5.2) sha256=53773669e414dc3bb070113befacb808576025a28cfa4a4accc682e90a9c1101
+  jekyll-seo-tag (2.8.0) sha256=3f2ed1916d56f14ebfa38e24acde9b7c946df70cb183af2cb5f0598f21ae6818
+  jekyll-theme-minima (0.1.1) sha256=82cde64d6b960412f0e0a31382b3b8bc020f0c4510d65036ba3eb89f2550bcba
+  jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
+  json (2.18.1) sha256=fe112755501b8d0466b5ada6cf50c8c3f41e897fa128ac5d263ec09eedc9f986
+  kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
+  liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mercenary (0.3.6) sha256=2a084b18f5692c86a633e185d5311ba6d11fc46c802eb414ae05368178078a82
+  minima (2.5.2) sha256=9c434e3b7bc4a0f0ab488910438ed3757a0502ff1060d172f361907fc38aa45a
+  minitest (6.0.1) sha256=7854c74f48e2e975969062833adc4013f249a4b212f5e7b9d5c040bf838d54bb
+  nokogiri (1.19.0-aarch64-linux-gnu) sha256=11a97ecc3c0e7e5edcf395720b10860ef493b768f6aa80c539573530bc933767
+  nokogiri (1.19.0-aarch64-linux-musl) sha256=eb70507f5e01bc23dad9b8dbec2b36ad0e61d227b42d292835020ff754fb7ba9
+  nokogiri (1.19.0-arm-linux-gnu) sha256=572a259026b2c8b7c161fdb6469fa2d0edd2b61cd599db4bbda93289abefbfe5
+  nokogiri (1.19.0-arm-linux-musl) sha256=23ed90922f1a38aed555d3de4d058e90850c731c5b756d191b3dc8055948e73c
+  nokogiri (1.19.0-arm64-darwin) sha256=0811dfd936d5f6dd3f6d32ef790568bf29b2b7bead9ba68866847b33c9cf5810
+  nokogiri (1.19.0-x86_64-darwin) sha256=1dad56220b603a8edb9750cd95798bffa2b8dd9dd9aa47f664009ee5b43e3067
+  nokogiri (1.19.0-x86_64-linux-gnu) sha256=f482b95c713d60031d48c44ce14562f8d2ce31e3a9e8dd0ccb131e9e5a68b58c
+  nokogiri (1.19.0-x86_64-linux-musl) sha256=1c4ca6b381622420073ce6043443af1d321e8ed93cc18b08e2666e5bd02ffae4
+  pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (3.30.0) sha256=a3d353222aa72e49e2c86726c0bcfd719f82592f57d494474655f48e669eceb6
+  safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
+  sass (3.7.4) sha256=808b0d39053aa69068df939e24671fe84fd5a9d3314486e1a1457d0934a4255d
+  sass-listen (4.0.0) sha256=ae9dcb76dd3e234329e5ba6e213f48e532c5a3e7b0b4d8a87f13aaca0cc18377
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+
+BUNDLED WITH
+  4.0.3

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ title: ADAMANT Improvement Proposals
 description: >-
   ADAMANT Improvement Proposals (AIPs) describe standards for the ADAMANT Messenger
   platform, including core protocol specifications and client APIs.
-url: "http://aips.adamant.im"
+url: "https://aips.adamant.im"
 twitter_username: adamant_im
 github_username:  Adamant-im
 header_pages:

--- a/_data/statuses.yaml
+++ b/_data/statuses.yaml
@@ -5,3 +5,4 @@
 - Deferred
 - Replaced
 - Rejected
+- Withdrawn

--- a/_includes/aipnums.html
+++ b/_includes/aipnums.html
@@ -1,4 +1,4 @@
 {% assign aips=include.aips|split:"," %}
 {% for aipnum in aips %}
-  <a href="{{aipnum|strip|prepend:"aip-" }}">{{aipnum|strip}}</a>{% if forloop.last == false %}, {% endif %}
+  <a href="{{ '/' | relative_url }}{{aipnum|strip|prepend:'aip-'}}/">{{aipnum|strip}}</a>{% if forloop.last == false %}, {% endif %}
 {% endfor %}

--- a/_includes/aiptable.html
+++ b/_includes/aiptable.html
@@ -1,12 +1,3 @@
-<style type="text/css">
-  .aiptable .title {
-    width: 67%;
-  }
-
-  .aiptable .author {
-    width: 33%;
-  }
-</style>
 {% for status in site.data.statuses %}
   {% assign aips = include.aips|where:"status",status|sort:"aip" %}
   {% assign count = aips|size %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,9 +13,7 @@
                         <div class="uk-grid-small uk-child-width-expand uk-flex-nowrap uk-flex-middle uk-grid"
                             uk-grid="">
                             <div class="uk-width-auto uk-first-column">
-                                <a href="https://adamant.im" class="uk-link-reset"><img
-                                        src="https://adamant.im/media/admwebsite.svg" class="el-image" alt="" width="20"
-                                        height="20"></a>
+                                <a href="https://adamant.im" class="uk-link-reset" aria-hidden="true"><svg class="el-image" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg></a>
                             </div>
                             <div>
                                 <div class="el-content">
@@ -30,14 +28,7 @@
                         <div class="uk-grid-small uk-child-width-expand uk-flex-nowrap uk-flex-middle uk-grid"
                             uk-grid="">
                             <div class="uk-width-auto uk-first-column">
-                                <span uk-icon="icon: thumbnails" class="el-image uk-text-muted uk-icon"
-                                    style='vertical-align:top'><svg width="20" height="20" viewBox="0 0 20 20"
-                                        xmlns="http://www.w3.org/2000/svg" ratio="1">
-                                        <rect fill="none" stroke="#000" x="3.5" y="3.5" width="5" height="5"></rect>
-                                        <rect fill="none" stroke="#000" x="11.5" y="3.5" width="5" height="5"></rect>
-                                        <rect fill="none" stroke="#000" x="11.5" y="11.5" width="5" height="5"></rect>
-                                        <rect fill="none" stroke="#000" x="3.5" y="11.5" width="5" height="5"></rect>
-                                    </svg></span>
+                                <a href="https://adamant.im/devs/" class="uk-link-reset uk-text-muted" aria-hidden="true"><svg class="el-image" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></a>
                             </div>
                             <div>
                                 <div class="el-content">
@@ -50,14 +41,7 @@
                         <div class="uk-grid-small uk-child-width-expand uk-flex-nowrap uk-flex-middle uk-grid"
                             uk-grid="">
                             <div class="uk-width-auto uk-first-column">
-                                <a href="https://github.com/adamant-im" class="uk-link-reset"><span
-                                        uk-icon="icon: github-alt" class="el-image uk-text-muted uk-icon"><svg
-                                            width="20" height="20" viewBox="0 0 20 20"
-                                            xmlns="http://www.w3.org/2000/svg" ratio="1">
-                                            <path
-                                                d="M10,0.5 C4.75,0.5 0.5,4.76 0.5,10.01 C0.5,15.26 4.75,19.51 10,19.51 C15.24,19.51 19.5,15.26 19.5,10.01 C19.5,4.76 15.25,0.5 10,0.5 L10,0.5 Z M12.81,17.69 C12.81,17.69 12.81,17.7 12.79,17.69 C12.47,17.75 12.35,17.59 12.35,17.36 L12.35,16.17 C12.35,15.45 12.09,14.92 11.58,14.56 C12.2,14.51 12.77,14.39 13.26,14.21 C13.87,13.98 14.36,13.69 14.74,13.29 C15.42,12.59 15.76,11.55 15.76,10.17 C15.76,9.25 15.45,8.46 14.83,7.8 C15.1,7.08 15.07,6.29 14.75,5.44 L14.51,5.42 C14.34,5.4 14.06,5.46 13.67,5.61 C13.25,5.78 12.79,6.03 12.31,6.35 C11.55,6.16 10.81,6.05 10.09,6.05 C9.36,6.05 8.61,6.15 7.88,6.35 C7.28,5.96 6.75,5.68 6.26,5.54 C6.07,5.47 5.9,5.44 5.78,5.44 L5.42,5.44 C5.06,6.29 5.04,7.08 5.32,7.8 C4.7,8.46 4.4,9.25 4.4,10.17 C4.4,11.94 4.96,13.16 6.08,13.84 C6.53,14.13 7.05,14.32 7.69,14.43 C8.03,14.5 8.32,14.54 8.55,14.55 C8.07,14.89 7.82,15.42 7.82,16.16 L7.82,17.51 C7.8,17.69 7.7,17.8 7.51,17.8 C4.21,16.74 1.82,13.65 1.82,10.01 C1.82,5.5 5.49,1.83 10,1.83 C14.5,1.83 18.17,5.5 18.17,10.01 C18.18,13.53 15.94,16.54 12.81,17.69 L12.81,17.69 Z">
-                                            </path>
-                                        </svg></span></a>
+                                <a href="https://github.com/adamant-im" class="uk-link-reset uk-text-muted" aria-hidden="true"><svg class="el-image" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg></a>
                             </div>
                             <div>
                                 <div class="el-content">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <div class="wrapper">
     <div class="uk-position-top-left">
       <a href="https://adamant.im" class="uk-navbar-item uk-adm-logo" target="_blank">
-      <img src="https://adamant.im/media/admlogo.svg" class="uk-responsive-height" alt=""></a>
+      <img src="https://adamant.im/wp-content/uploads/whitelogo.svg" class="uk-responsive-height" alt=""></a>
     </div>
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="site-header" role="banner">
   <div class="wrapper">
     <div class="uk-position-top-left">
-      <a href="https://adamant.im" class="uk-navbar-item uk-adm-logo" target="_blank">
+      <a href="{{ "/" | relative_url }}" class="uk-navbar-item uk-adm-logo">
       <img src="https://adamant.im/wp-content/uploads/whitelogo.svg" class="uk-responsive-height" alt=""></a>
     </div>
     {%- assign default_paths = site.pages | map: "path" -%}

--- a/_layouts/aip.html
+++ b/_layouts/aip.html
@@ -20,7 +20,7 @@ layout: default
     {% if page["discussions-to"] != undefined %}
     <tr>
       <th>Discussions-To</th>
-      <td><a href="{{ page[" discussions-to"] | uri_escape }}">{{ page["discussions-to"] | xml_escape }}</a></td>
+      <td><a href="{{ page["discussions-to"] | uri_escape }}">{{ page["discussions-to"] | xml_escape }}</a></td>
     </tr>
     {% endif %}
     <tr>

--- a/aip-X.md
+++ b/aip-X.md
@@ -20,7 +20,7 @@ The title should be 44 characters or less.
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the AIP.-->
-If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the AIP.
+"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the AIP.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -54,9 +54,30 @@ body {
     margin-left:0;
 }
 .uk-list-footer li {
-    line-height: 40px;
+    line-height: 1.2;
     white-space: nowrap;
-
+    padding-top: 0.7em;
+}
+.uk-list-footer .uk-grid {
+    display: flex;
+    align-items: center;
+}
+.uk-list-footer .uk-grid > .uk-width-auto {
+    flex: 0 0 auto;
+    padding-right: 1rem;
+    display: flex;
+    align-items: center;
+}
+.uk-list-footer .uk-grid > .uk-width-auto a {
+    display: flex;
+    align-items: center;
+    line-height: 0;
+}
+.uk-list-footer .uk-grid > .uk-width-auto svg {
+    display: block;
+}
+.uk-list-footer .el-content {
+    line-height: 1.2;
 }
 
 .uk-child-width-expand>:not([class*=uk-width]) {
@@ -76,13 +97,8 @@ body {
     width: 1px;
 }
 .uk-first-column {
-    float: left;
     width: auto!important;
     padding-right: 1rem;
-    max-height: 40px;
-}
-.uk-first-column svg {
-    vertical-align:middle;
 }
 .footer-col-1 {
     width: -webkit-calc(50% - (30px / 2));

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -11,8 +11,8 @@
     max-width: calc(960px - (30px * 2));
 }
 .uk-position-top-left {
-    top: 0.7rem;
-    left: 30px;
+    top: 0.2rem;
+    left: 20px;
     position: absolute;
 }
 .site-nav {
@@ -27,6 +27,7 @@
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
     border-radius: 50%;
     display: block;
+    padding: 5px;
 }
 .uk-adm-logo:hover {
     box-shadow: 0 0px 3px rgba(0, 0, 0, 0.1);

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -55,17 +55,24 @@ a:hover {
   padding-right: 15px;
 }
 
-// Header
+// Header — full-width bar
 .site-header {
+  width: 100%;
+  box-sizing: border-box;
   padding-top: 1.25rem;
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--adm-border);
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--adm-bg-subtle);
+  box-shadow: 0 1px 0 0 var(--adm-border);
+}
+.site-header .wrapper {
+  max-width: -webkit-calc(960px - (30px * 2));
+  max-width: calc(960px - (30px * 2));
 }
 
 .uk-position-top-left {
   top: 0.35rem;
-  left: 20px;
+  left: 5px;
   position: absolute;
 }
 .site-nav {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -2,122 +2,270 @@
 ---
 
 @import "{{ site.theme }}";
-@import url('https://fonts.googleapis.com/css?family=Montserrat');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');
 
+// ADAMANT-aligned palette: clean, minimal, professional
+:root {
+  --adm-accent: #0066a8;
+  --adm-accent-hover: #004d80;
+  --adm-muted: #5a6c7d;
+  --adm-border: #e2e8f0;
+  --adm-bg-subtle: #f8fafc;
+  --adm-text: #1e293b;
+  --adm-text-muted: #64748b;
+}
+
+body {
+  background-color: #fff;
+  background-image: url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23e2e8f0' fill-opacity='0.6' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E");
+  font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--adm-text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+// Typography
+h1, h2, h3, h4, h5, h6 {
+  color: var(--adm-text);
+  font-weight: 600;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+h1 { font-size: 1.75rem; margin-top: 0; }
+h2 { font-size: 1.35rem; border-bottom: 1px solid var(--adm-border); padding-bottom: 0.35em; }
+h3 { font-size: 1.15rem; }
+
+a {
+  color: var(--adm-accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--adm-accent-hover);
+  text-decoration: underline;
+}
 
 .wrapper {
-    position: relative;
-    max-width: -webkit-calc(960px - (30px * 2));
-    max-width: calc(960px - (30px * 2));
+  position: relative;
+  max-width: -webkit-calc(960px - (30px * 2));
+  max-width: calc(960px - (30px * 2));
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 15px;
+  padding-right: 15px;
 }
+
+// Header
+.site-header {
+  padding-top: 1.25rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--adm-border);
+  background: rgba(255, 255, 255, 0.95);
+}
+
 .uk-position-top-left {
-    top: 0.2rem;
-    left: 20px;
-    position: absolute;
+  top: 0.35rem;
+  left: 20px;
+  position: absolute;
 }
 .site-nav {
-    z-index: 100; 
+  z-index: 100;
 }
 .uk-adm-logo {
-    border: solid #eee;
-    border-width: 1px;
-    background: rgba(255, 255, 255, 1);
-    z-index: 1000;
-    position: relative;
-    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
-    border-radius: 50%;
-    display: block;
-    padding: 5px;
+  border: 1px solid var(--adm-border);
+  background: #fff;
+  z-index: 1000;
+  position: relative;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  border-radius: 50%;
+  display: block;
+  padding: 6px;
+  transition: box-shadow 0.2s ease;
 }
 .uk-adm-logo:hover {
-    box-shadow: 0 0px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 102, 168, 0.15);
 }
 .site-title {
-    float: right;
+  float: right;
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--adm-text);
 }
-.site-header {
-    padding-top: 20px;
+.site-title:hover {
+  color: var(--adm-accent);
+  text-decoration: none;
 }
 .uk-responsive-height {
-    max-height: 100%;
-    width: auto;
-    max-width: none;
-    width: 78px;
+  max-height: 100%;
+  width: auto;
+  max-width: none;
+  width: 78px;
 }
-body {
-    background-color: white;
-    background-image: url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23eeeeee' fill-opacity='1' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E");
-    font-family: 'Montserrat', sans-serif;
+
+// Main content
+.main-content,
+.page-content {
+  padding-top: 1.5rem;
+  padding-bottom: 2rem;
+}
+.post-content,
+.page-content p {
+  margin-bottom: 1em;
+}
+.page-heading {
+  font-size: 1.5rem;
+  margin-bottom: 0.5em;
+}
+
+// Navigation links (minima .page-link)
+.site-nav .page-link {
+  color: var(--adm-text);
+  font-weight: 500;
+  margin-left: 1.25rem;
+}
+.site-nav .page-link:hover {
+  color: var(--adm-accent);
+  text-decoration: none;
+}
+
+// Tables (AIP metadata + aiptable)
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.25em 0;
+  font-size: 0.95rem;
+}
+th, td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border: 1px solid var(--adm-border);
+}
+th {
+  background: var(--adm-bg-subtle);
+  font-weight: 600;
+  color: var(--adm-text);
+}
+tr:nth-child(even) {
+  background: rgba(248, 250, 252, 0.6);
+}
+.aiptable .title { width: 67%; }
+.aiptable .author { width: 33%; }
+.aiptable .aipnum { width: 120px; }
+.aiptable a { font-weight: 500; }
+
+// Footer
+.site-footer {
+  border-top: 1px solid var(--adm-border);
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+  background: var(--adm-bg-subtle);
+  margin-top: 2rem;
+}
+.site-footer .wrapper {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.footer-heading {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--adm-text);
+  margin-bottom: 0.75rem;
+}
+.site-footer p {
+  color: var(--adm-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.uk-list-footer .el-link,
+.uk-list-footer a {
+  color: var(--adm-accent);
+}
+.uk-list-footer a:hover {
+  color: var(--adm-accent-hover);
 }
 
 .uk-list {
-    list-style: none;
-    margin-left:0;
+  list-style: none;
+  margin-left: 0;
 }
 .uk-list-footer li {
-    line-height: 1.2;
-    white-space: nowrap;
-    padding-top: 0.7em;
+  line-height: 1.4;
+  white-space: nowrap;
+  padding-top: 0.6em;
 }
 .uk-list-footer .uk-grid {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 .uk-list-footer .uk-grid > .uk-width-auto {
-    flex: 0 0 auto;
-    padding-right: 1rem;
-    display: flex;
-    align-items: center;
+  flex: 0 0 auto;
+  padding-right: 1rem;
+  display: flex;
+  align-items: center;
 }
 .uk-list-footer .uk-grid > .uk-width-auto a {
-    display: flex;
-    align-items: center;
-    line-height: 0;
+  display: flex;
+  align-items: center;
+  line-height: 0;
 }
 .uk-list-footer .uk-grid > .uk-width-auto svg {
-    display: block;
+  display: block;
 }
 .uk-list-footer .el-content {
-    line-height: 1.2;
+  line-height: 1.3;
 }
 
-.uk-child-width-expand>:not([class*=uk-width]) {
-    flex: 1;
-    min-width: 0;
-    flex-basis: 1px;
+// Utility (footer grid)
+.uk-child-width-expand > :not([class*="uk-width"]) {
+  flex: 1;
+  min-width: 0;
+  flex-basis: 1px;
 }
-.uk-width-auto {
-    width: auto;
+.uk-width-auto { width: auto; }
+[class*="uk-width"] {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
 }
-[class*=uk-width] {
-    box-sizing: border-box;
-    width: 100%;
-    max-width: 100%;
-}
-.uk-child-width-expand>* {
-    width: 1px;
-}
+.uk-child-width-expand > * { width: 1px; }
 .uk-first-column {
-    width: auto!important;
-    padding-right: 1rem;
+  width: auto !important;
+  padding-right: 1rem;
 }
 .footer-col-1 {
-    width: -webkit-calc(50% - (30px / 2));
-    width: calc(50% - (30px / 2));
+  width: -webkit-calc(50% - (30px / 2));
+  width: calc(50% - (30px / 2));
 }
-[class*=uk-child-width]>* {
-    box-sizing: border-box;
-    width: 100%;
+[class*="uk-child-width"] > * {
+  box-sizing: border-box;
+  width: 100%;
 }
-.uk-grid-small>* {
-    padding-left: 20px;
+.uk-grid-small > * { padding-left: 20px; }
+
+// Home / AIP list subtle spacing
+.home h2 { margin-top: 1.75em; }
+.home ul { padding-left: 1.5em; }
+.home li { margin-bottom: 0.35em; }
+
+// 404 page
+.page-404 {
+  margin: 3rem auto;
+  max-width: 480px;
+  text-align: center;
 }
+.page-404-title {
+  font-size: 3rem;
+  font-weight: 700;
+  color: var(--adm-text-muted);
+  margin-bottom: 0.5rem;
+}
+.page-404 p { margin-bottom: 0.75em; }
+.page-404 a { font-weight: 500; }
 
 @media screen and (max-width: 600px) {
-    .uk-position-top-left {
-        display:none;
-    }
-    .site-title {
-        float:left;
-    }
+  .uk-position-top-left { display: none; }
+  .site-title { float: left; }
+  .site-header { padding-bottom: 0.75rem; }
+  table { font-size: 0.875rem; }
+  th, td { padding: 0.5rem; }
 }

--- a/core.html
+++ b/core.html
@@ -3,5 +3,5 @@ layout: page
 title: Core
 ---
 
-{% assign aips=site.pages|where:"type","Standard"|where:"category","Core" %}
+{% assign aips=site.pages|where:"type","Standards"|where:"category","Core" %}
 {% include aiptable.html aips=aips %}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Home
 <p>ADAMANT Improvement Proposals (AIPs) describe standards for the ADAMANT Messenger platform, including core protocol specifications, and client APIs.</p>
 
 <h2>Contributing</h2>
-<p>First review <a href="AIPS/aip-1">AIP-1</a>. Then clone the repository and add your AIP to it. There is a <a href="https://github.com/Adamant-im/AIPs/blob/master/aip-X.md">template AIP here</a>. Then submit a Pull Request to ADAMANT's <a href="https://github.com/Adamant-im/AIPs">AIPs repository</a>.</p>
+<p>First review <a href="{{ '/aip-1/' | relative_url }}">AIP-1</a>. Then clone the repository and add your AIP to it. There is a <a href="https://github.com/Adamant-im/AIPs/blob/master/aip-X.md">template AIP here</a>. Then submit a Pull Request to ADAMANT's <a href="https://github.com/Adamant-im/AIPs">AIPs repository</a>.</p>
 
 <h2>AIP status terms</h2>
 <ul>

--- a/networking.html
+++ b/networking.html
@@ -3,5 +3,5 @@ layout: page
 title: Networking
 ---
 
-{% assign aips=site.pages|where:"type","Standard"|where:"category","Networking" %}
+{% assign aips=site.pages|where:"type","Standards"|where:"category","Networking" %}
 {% include aiptable.html aips=aips %}


### PR DESCRIPTION
## Description

This PR contains small updates and fixes across the AIPs Jekyll site:

- **Jekyll setup**: Added `Gemfile` and `Gemfile.lock` for reproducible Jekyll builds (Jekyll ~3.9, minima theme, jekyll-feed, kramdown-parser-gfm, webrick).
- **Header**: Logo link changed from absolute `https://adamant.im` to relative `{{ "/" | relative_url }}` for portability; logo image updated to `whitelogo.svg`.
- **Footer**: Replaced inline UIkit icons with simpler SVG icons (GitHub, devs link); improved footer layout and accessibility (flex layout, `aria-hidden`, link styling).
- **Styles** (`assets/main.scss`): Adjusted logo position (top/left), logo padding, footer list line-height and spacing, flex alignment for footer grids; removed float/max-height on icon column.
- **Content fixes**: In AIP-1 — fixed anchor `eip-editor` → `aip-editor`, `Aip-X` → `aip-X` in assets path, "Ethereum" → "ADAMANT"; in `aip-X.md` template — fixed missing opening quote in Simple Summary; in `_layouts/aip.html` — fixed Liquid spacing in `discussions-to` key.
- **URLs**: `index.html` — AIP-1 link uses `relative_url`; `_config.yml` and `_includes/aipnums.html` — minor URL/text consistency updates.
- **Data**: `_data/statuses.yaml` — one status entry update.
- **Listing fix**: `core.html` and `networking.html` — filter `type` changed from `"Standard"` to `"Standards"` so AIPs list correctly.

## Related issue

None.

## External links (optional)

N/A

## Screenshots or videos

<img width="1158" height="777" alt="image" src="https://github.com/user-attachments/assets/a9d406bc-c928-4f94-b62b-98d099131746" />

## Breaking changes

Does this PR introduce changes that break backward compatibility?  
If yes, describe the impact and migration path.

No. All changes are internal (templates, styles, docs, config). Relative URLs may behave differently only when the site is served from a non-root path; if the site is always at the repo root, behavior is unchanged.

## How to test

1. **Build**: From repo root run `bundle install` then `bundle exec jekyll serve`. Confirm the site builds and serves without errors.
2. **Header**: Open the site root; click the logo and confirm it navigates to `/` (or the correct base URL). Confirm the logo image (whitelogo) displays.
3. **Footer**: Check footer links (GitHub, devs) open correct URLs; icons render and layout looks correct on narrow and wide viewports.
4. **Content**: Open AIP-1 and check the "AIP editor responsibilities" anchor works; open an AIP with Discussions-To and confirm the link renders. Open Core and Networking pages and confirm AIP tables list entries (type "Standards").
5. **Template**: Create a new AIP from `aip-X.md` and confirm the Simple Summary line has the quote correctly.

## Notes for reviewers

- Logo now points to site root via `relative_url` — correct for GitHub Pages and any baseurl.
- `core.html` / `networking.html` type change from "Standard" to "Standards" is critical for AIP listing; confirm existing AIPs use `type: Standards` in front matter.
- Footer SVG markup is intentionally minimal (no UIkit icon dependency) for simpler maintenance and accessibility.

## Checklist

- [x] Code is formatted
- [ ] Tests added/updated (if needed)
- [ ] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
