### PR TITLE
Add draft AIP for timestampMs transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .vscode/
+
+# Code Editors
+.DS_Store
+.ed25519-node
+.idea/
+.project
+.vscode/
+__MACOSX/

--- a/AIPS/aip-11.md
+++ b/AIPS/aip-11.md
@@ -4,7 +4,7 @@ title: Behavior for KVS data
 author: Aleksei Lebedev
 discussions-to: https://github.com/Adamant-im/AIPs/issues/27
 requires: 3
-extends: https://aips.adamant.im/AIPS/aip-3
+extends: 3
 status: Draft
 type: Standards
 category: ARC

--- a/AIPS/aip-12.md
+++ b/AIPS/aip-12.md
@@ -4,7 +4,7 @@ title: Non-ADM crypto transfer messages
 author: Aleksei Lebedev (@adamant-al)
 discussions-to: https://github.com/Adamant-im/AIPs/issues/29
 requires: 5
-extends: https://aips.adamant.im/AIPS/aip-5
+extends: 5
 status: Accepted
 type: Standards
 category: ARC

--- a/AIPS/aip-16.md
+++ b/AIPS/aip-16.md
@@ -4,7 +4,7 @@ title: Quote/reply messages
 author: Aleksei Lebedev (@adamant-al)
 discussions-to: https://github.com/Adamant-im/AIPs/issues/48
 requires: 5
-extends: https://aips.adamant.im/AIPS/aip-5
+extends: 5
 status: Accepted
 type: Standards
 category: ARC

--- a/AIPS/aip-17.md
+++ b/AIPS/aip-17.md
@@ -4,7 +4,7 @@ title: Reactions to Messages
 author: Aleksei Lebedev (@adamant-al), Stanislav Jelezoglo (@StanislavDevIOS)
 discussions-to: https://github.com/Adamant-im/AIPs/issues/52
 requires: 5
-extends: https://aips.adamant.im/AIPS/aip-5
+extends: 5
 status: Accepted
 type: Standards
 category: ARC

--- a/AIPS/aip-18.md
+++ b/AIPS/aip-18.md
@@ -4,7 +4,7 @@ title: Decentralized File Transfer
 author: Aleksei Lebedev (@adamant-al), Stanislav Jelezoglo (@StanislavDevIOS)
 discussions-to: https://github.com/Adamant-im/AIPs/issues/55
 requires: 5
-extends: https://aips.adamant.im/AIPS/aip-5
+extends: 5
 status: Accepted
 type: Standards
 category: ARC

--- a/AIPS/aip-8.md
+++ b/AIPS/aip-8.md
@@ -3,7 +3,7 @@ aip: 8
 title: URI Format for ADAMANT
 author: Aleksei Lebedev
 discussions-to: https://github.com/Adamant-im/AIPs/issues/16
-extends: https://aips.adamant.im/AIPS/aip-2
+extends: 2
 status: Accepted
 type: Standards
 category: ARC

--- a/AIPS/aip-draft_timestamp_ms.md
+++ b/AIPS/aip-draft_timestamp_ms.md
@@ -1,0 +1,160 @@
+---
+aip: <to be assigned>
+title: Transaction Millisecond Timestamp
+author: ADAMANT contributors
+discussions-to: https://github.com/Adamant-im/adamant/issues/209
+status: Draft
+type: Standards
+category: Core
+created: 2026-05-07
+---
+
+## Simple Summary
+
+Add an optional `timestampMs` field to ADAMANT transactions so clients and nodes can preserve millisecond-level creation time without changing transaction IDs or signatures.
+
+## Abstract
+
+ADAMANT transactions currently include `timestamp`, measured in seconds since the ADAMANT epoch. This value is part of transaction signing and cannot be adjusted by a node after a client creates a transaction. In fast messaging flows, several messages can share the same second-level timestamp, so clients and APIs cannot always reconstruct the intended ordering from confirmed transaction data.
+
+This AIP proposes a protocol upgrade that allows transactions to include `timestampMs`, measured in Unix milliseconds. The field is not included in transaction byte serialization, signature calculation, transaction IDs, or hashes. After activation, nodes validate that an included `timestampMs` belongs to the same ADAMANT timestamp second, store it, and return it in transaction API and socket responses. Before activation, nodes must ignore the field on consensus-sensitive paths.
+
+## Motivation
+
+Fast chat conversations can create multiple message transactions within the same second. Sorting by the existing `timestamp` field alone is not precise enough to keep the sender's intended order.
+
+Changing `timestamp` itself, transaction byte serialization, or signature semantics would be a much larger consensus change. It would also risk historical replay compatibility. A soft companion field gives clients better ordering data while preserving existing transaction identity and signature rules.
+
+## Specification
+
+### Field Definition
+
+Transactions MAY include:
+
+```json
+{
+  "timestampMs": 1724939434123
+}
+```
+
+`timestampMs` is a Unix timestamp in milliseconds. It describes the client-side transaction creation time.
+
+### Serialization and Identity
+
+`timestampMs` MUST NOT be included in transaction byte serialization.
+
+`timestampMs` MUST NOT affect:
+
+- transaction signatures
+- second signatures
+- multisignature checks
+- transaction IDs
+- transaction hashes
+- block IDs or block hashes
+
+### Activation
+
+This change MUST be gated by an explicit consensus activation height.
+
+Before activation:
+
+- nodes MUST ignore `timestampMs` during transaction object normalization
+- nodes MUST NOT store `timestampMs` from newly processed blocks
+- nodes MUST remain compatible with peers and clients that include or omit the field
+
+At and after activation:
+
+- nodes MUST preserve `timestampMs` during transaction object normalization
+- nodes MUST validate `timestampMs` when it is present
+- nodes MUST store `timestampMs` in transaction storage
+- nodes MUST expose `timestampMs` in transaction API responses and socket transaction payloads when the stored value exists
+
+Activation checks MUST be based on the height of the block or transaction validation context being processed. Implementations MUST NOT decide activation for historical block processing solely from the node's current tip height.
+
+### Validation
+
+After activation, when a transaction includes `timestampMs`, the node MUST verify that it belongs to the same ADAMANT timestamp second as `timestamp`.
+
+Let:
+
+- `epochMs` be the ADAMANT epoch in Unix milliseconds
+- `timestampMsFromAdamant = epochMs + timestamp * 1000`
+- `deltaMs = timestampMs - timestampMsFromAdamant`
+
+The transaction is valid only when:
+
+```text
+0 <= deltaMs < 1000
+```
+
+This rule preserves consistency between the signed second-level timestamp and the unsigned millisecond companion field.
+
+Nodes MAY keep public API admission checks that compare a newly submitted transaction timestamp with local node time. Such checks are node admission policy and MUST NOT be used for deterministic block replay validity.
+
+### Sorting
+
+When a transaction listing, chat listing, state listing, or unconfirmed transaction merge sorts by `timestamp`, implementations SHOULD sort by:
+
+1. `timestampMs`, when present
+2. `timestamp * 1000`, when `timestampMs` is not present
+
+Implementations SHOULD keep the existing `timestamp` sort direction as a secondary tie-breaker.
+
+### Client Behavior
+
+Clients SHOULD include `timestampMs` with every newly created transaction after they know the network supports this AIP.
+
+Clients SHOULD verify that `timestampMs` belongs to the same ADAMANT timestamp second as `timestamp` before trusting transaction data for local ordering.
+
+Clients SHOULD prefer `timestampMs` over `timestamp` when sorting messages and transactions. If `timestampMs` is missing, clients MUST fall back to `timestamp`.
+
+## Rationale
+
+The proposal deliberately keeps `timestampMs` outside transaction signatures and IDs. This avoids changing transaction identity, block identity, and historical replay semantics.
+
+The field is still activation-gated because storing and validating additional transaction data during block processing affects deterministic node behavior. The activation boundary makes upgraded nodes compatible with old chain history and makes the new rule explicit for all implementations.
+
+The validation rule uses the same second as the signed `timestamp` instead of a wider tolerance. This prevents a node or relay from attaching an arbitrary millisecond value that would materially change ordering while keeping the signed second unchanged.
+
+Current-time freshness checks are intentionally left out of consensus validation. A check such as "not more than N seconds in the past" depends on wall-clock time and is not replay-stable. Nodes may use such checks only when accepting new transactions from public APIs.
+
+## Backwards Compatibility
+
+Before activation, upgraded nodes ignore `timestampMs` in consensus-sensitive transaction normalization. This allows old and upgraded nodes to process existing history and pre-activation blocks consistently.
+
+After activation, nodes that have not upgraded will not understand the new validation and storage rules. The activation height therefore requires normal network coordination.
+
+Transactions without `timestampMs` remain valid after activation. This keeps older clients and tools functional, while clients that need millisecond ordering can opt in by including the field.
+
+API consumers must treat `timestampMs` as optional because historical transactions and transactions from older clients may not contain it.
+
+## Test Cases
+
+Implementations of this AIP MUST include tests for:
+
+- transaction byte serialization, signature, ID, and hash stability when `timestampMs` changes
+- pre-activation transaction normalization removing `timestampMs`
+- post-activation transaction normalization preserving `timestampMs`
+- post-activation validation accepting `0 <= deltaMs < 1000`
+- post-activation validation rejecting negative or at least 1000 ms deltas
+- block processing at the activation boundary using the validated block height
+- database storage and API response projection of `timestampMs`
+- transaction and chat sorting by `timestampMs` with fallback to `timestamp`
+- replay or synchronization of pre-activation history
+
+## Implementation
+
+Reference implementation work is tracked in:
+
+- Node issue: https://github.com/Adamant-im/adamant/issues/209
+- Initial node implementation: https://github.com/Adamant-im/adamant/pull/93
+
+Companion updates may be required in:
+
+- ADAMANT API schema
+- ADAMANT documentation
+- ADAMANT client applications and libraries
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.9"
-gem "jekyll-theme-minima"
-gem "jekyll-feed"
-gem "kramdown-parser-gfm"
-gem "webrick"
+gem "jekyll", "~> 4.4"
+gem "minima", "~> 2.5"
+gem "jekyll-feed", "~> 0.17"
+gem "kramdown-parser-gfm", "~> 1.1"
+gem "webrick", "~> 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,75 +1,75 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (4.0.1)
     colorator (1.1.0)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
     csv (3.3.5)
-    drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.3-aarch64-linux-gnu)
-    ffi (1.17.3-aarch64-linux-musl)
-    ffi (1.17.3-arm-linux-gnu)
-    ffi (1.17.3-arm-linux-musl)
-    ffi (1.17.3-arm64-darwin)
-    ffi (1.17.3-x86_64-darwin)
-    ffi (1.17.3-x86_64-linux-gnu)
-    ffi (1.17.3-x86_64-linux-musl)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    html-pipeline (2.14.3)
-      activesupport (>= 2)
-      nokogiri (>= 1.4)
+    google-protobuf (4.34.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    jekyll (3.10.0)
+    jekyll (4.4.1)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
       csv (~> 3.0)
       em-websocket (~> 0.5)
-      i18n (>= 0.7, < 2)
-      jekyll-sass-converter (~> 1.0)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
-      kramdown (>= 1.17, < 3)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.3.3)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 4)
+      rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
-      webrick (>= 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-mentions (1.6.0)
-      html-pipeline (~> 2.3)
-      jekyll (>= 3.7, < 5.0)
-    jekyll-sass-converter (1.5.2)
-      sass (~> 3.4)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
-    jekyll-theme-minima (0.1.1)
-      jekyll (~> 3.8)
-      jekyll-mentions
-      minima
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.18.1)
@@ -83,49 +83,40 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    mercenary (0.3.6)
+    mercenary (0.4.0)
     minima (2.5.2)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (6.0.1)
-      prism (~> 1.5)
-    nokogiri (1.19.0-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.0-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.0-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.0-arm-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.0-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.19.0-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.19.0-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.0-x86_64-linux-musl)
-      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    prism (1.9.0)
-    public_suffix (7.0.2)
-    racc (1.8.1)
+    public_suffix (7.0.5)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
-    rouge (3.30.0)
+    rouge (4.7.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    securerandom (0.4.1)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
-    uri (1.1.1)
+    sass-embedded (1.99.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
     webrick (1.9.2)
 
 PLATFORMS
@@ -139,42 +130,43 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  jekyll (~> 3.9)
-  jekyll-feed
-  jekyll-theme-minima
-  kramdown-parser-gfm
-  webrick
+  jekyll (~> 4.4)
+  jekyll-feed (~> 0.17)
+  kramdown-parser-gfm (~> 1.1)
+  minima (~> 2.5)
+  webrick (~> 1.9)
 
 CHECKSUMS
-  activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
-  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
-  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
-  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
   eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
-  ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
-  ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
-  ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
-  ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
-  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
-  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
-  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
-  ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
+  ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
+  ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
+  ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
+  ffi (1.17.4-arm-linux-musl) sha256=9d4838ded0465bef6e2426935f6bcc93134b6616785a84ffd2a3d82bc3cf6f95
+  ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
+  ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
-  html-pipeline (2.14.3) sha256=8a1d4d7128b2141913387cac0f8ba898bb6812557001acc0c2b46910f59413a0
+  google-protobuf (4.34.1) sha256=347181542b8d659c60f028fa3791c9cccce651a91ad27782dbc5c5e374796cdc
+  google-protobuf (4.34.1-aarch64-linux-gnu) sha256=f9c07607dc139c895f2792a7740fcd01cd94d4d7b0e0a939045b50d7999f0b1d
+  google-protobuf (4.34.1-aarch64-linux-musl) sha256=db58e5a4a492b43c6614486aea31b7fb86955b175d1d48f28ebf388f058d78a9
+  google-protobuf (4.34.1-arm64-darwin) sha256=2745061f973119e6e7f3c81a0c77025d291a3caa6585a2cd24a25bbc7bedb267
+  google-protobuf (4.34.1-x86_64-darwin) sha256=4dc498376e218871613589c4d872400d42ad9ae0c700bdb2606fe1c77a593075
+  google-protobuf (4.34.1-x86_64-linux-gnu) sha256=87088c9fd8e47b5b40ca498fc1195add6149e941ff7e81c532a5b0b8876d4cc9
+  google-protobuf (4.34.1-x86_64-linux-musl) sha256=8c0e91436fbe504ffc64f0bd621f2e69adbcce8ed2c58439d7a21117069cfdd7
   http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
-  jekyll (3.10.0) sha256=c4213b761dc7dfe7d499eb742d0476a02d8503e440c2610e19774ee7f0db8d90
+  jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
-  jekyll-mentions (1.6.0) sha256=39e801024cb6f2319b3f78a29999d0068ef5f68bc5202b8757d5354fef311ed9
-  jekyll-sass-converter (1.5.2) sha256=53773669e414dc3bb070113befacb808576025a28cfa4a4accc682e90a9c1101
+  jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
   jekyll-seo-tag (2.8.0) sha256=3f2ed1916d56f14ebfa38e24acde9b7c946df70cb183af2cb5f0598f21ae6818
-  jekyll-theme-minima (0.1.1) sha256=82cde64d6b960412f0e0a31382b3b8bc020f0c4510d65036ba3eb89f2550bcba
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
   json (2.18.1) sha256=fe112755501b8d0466b5ada6cf50c8c3f41e897fa128ac5d263ec09eedc9f986
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
@@ -182,32 +174,27 @@ CHECKSUMS
   liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mercenary (0.3.6) sha256=2a084b18f5692c86a633e185d5311ba6d11fc46c802eb414ae05368178078a82
+  mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
   minima (2.5.2) sha256=9c434e3b7bc4a0f0ab488910438ed3757a0502ff1060d172f361907fc38aa45a
-  minitest (6.0.1) sha256=7854c74f48e2e975969062833adc4013f249a4b212f5e7b9d5c040bf838d54bb
-  nokogiri (1.19.0-aarch64-linux-gnu) sha256=11a97ecc3c0e7e5edcf395720b10860ef493b768f6aa80c539573530bc933767
-  nokogiri (1.19.0-aarch64-linux-musl) sha256=eb70507f5e01bc23dad9b8dbec2b36ad0e61d227b42d292835020ff754fb7ba9
-  nokogiri (1.19.0-arm-linux-gnu) sha256=572a259026b2c8b7c161fdb6469fa2d0edd2b61cd599db4bbda93289abefbfe5
-  nokogiri (1.19.0-arm-linux-musl) sha256=23ed90922f1a38aed555d3de4d058e90850c731c5b756d191b3dc8055948e73c
-  nokogiri (1.19.0-arm64-darwin) sha256=0811dfd936d5f6dd3f6d32ef790568bf29b2b7bead9ba68866847b33c9cf5810
-  nokogiri (1.19.0-x86_64-darwin) sha256=1dad56220b603a8edb9750cd95798bffa2b8dd9dd9aa47f664009ee5b43e3067
-  nokogiri (1.19.0-x86_64-linux-gnu) sha256=f482b95c713d60031d48c44ce14562f8d2ce31e3a9e8dd0ccb131e9e5a68b58c
-  nokogiri (1.19.0-x86_64-linux-musl) sha256=1c4ca6b381622420073ce6043443af1d321e8ed93cc18b08e2666e5bd02ffae4
   pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
-  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
-  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
-  rouge (3.30.0) sha256=a3d353222aa72e49e2c86726c0bcfd719f82592f57d494474655f48e669eceb6
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
   safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
-  sass (3.7.4) sha256=808b0d39053aa69068df939e24671fe84fd5a9d3314486e1a1457d0934a4255d
-  sass-listen (4.0.0) sha256=ae9dcb76dd3e234329e5ba6e213f48e532c5a3e7b0b4d8a87f13aaca0cc18377
-  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
-  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  sass-embedded (1.99.0-aarch64-linux-gnu) sha256=a46615b0295ca7bd979b9ce79f6b9f1d26881736400188bd6fd5c4b7c9b46473
+  sass-embedded (1.99.0-aarch64-linux-musl) sha256=eaa6d56968909d1d54073c46e21c13fd5bbcb5af609d7e4fbe6b196426ca8e49
+  sass-embedded (1.99.0-arm-linux-gnueabihf) sha256=f5f0748934660cda6948917af6dc974caf4d36ea6121e450982153b7d9c49b55
+  sass-embedded (1.99.0-arm-linux-musleabihf) sha256=29a4056e76bc136025ba5d03e82d86ecdabfb6c07a473a4fdedcd72fb28dbbc4
+  sass-embedded (1.99.0-arm64-darwin) sha256=20773f2fb0e8f4d0194eb1874dab4c0ef60262ff6dafe29361e217beb2208629
+  sass-embedded (1.99.0-x86_64-darwin) sha256=371774c83b6dce8a2cb7b5ce5a0f918ff2735bf200b00e3bc7067366654fff13
+  sass-embedded (1.99.0-x86_64-linux-gnu) sha256=a4e2ae5e9951815cb8b3ab408cee8b800852491988a57de735f18d259c70d7c4
+  sass-embedded (1.99.0-x86_64-linux-musl) sha256=94be72a6f856c610e67b12303dc76a58412e64b24ce97bdf4912199b8145c8dd
+  terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
 
 BUNDLED WITH
-  4.0.3
+  4.0.10

--- a/README.md
+++ b/README.md
@@ -2,6 +2,44 @@
 
 ADAMANT Improvement Proposal (AIPs) repository describe standards for the ADAMANT Messenger platform, including core protocol specifications and client APIs.
 
+## Site build
+
+This repository is built as a Jekyll site.
+
+- Ruby gems are managed with Bundler via [Gemfile](Gemfile)
+- The site currently builds with Jekyll 4.x and the `minima` theme
+- Local build output is generated into [_site](_site)
+
+### Local setup
+
+Install dependencies:
+
+```sh
+bundle install
+```
+
+Run the local development server:
+
+```sh
+bundle exec jekyll serve
+```
+
+Build the site without serving it:
+
+```sh
+bundle exec jekyll build
+```
+
+If you change [_config.yml](_config.yml), restart `jekyll serve`, because Jekyll does not reload that file automatically.
+
+In VS Code, this workspace disables built-in SCSS validation because Jekyll entrypoint stylesheets with front matter can trigger false parser errors even when `bundle exec jekyll build` succeeds.
+
+### Deployment
+
+The published site is deployed to GitHub Pages for the [Adamant-im/AIPs](https://github.com/Adamant-im/AIPs) repository and served on the custom domain `https://aips.adamant.im` configured in [CNAME](CNAME).
+
+GitHub Pages is configured to publish from the `master` branch. The settings page itself is not publicly readable without repository access, so this README documents the verified public deployment target, branch, and local build process.
+
 ## Contributing
 
  1. Review [AIP-1](AIPS/aip-1.md).

--- a/_config.yml
+++ b/_config.yml
@@ -33,8 +33,12 @@ header_pages:
 # Build settings
 markdown: kramdown
 
-kramdown: 
+kramdown:
   input: GFM
+
+sass:
+  quiet_deps: true
+
 theme: minima
 plugins:
   - jekyll-feed

--- a/_includes/aipnums.html
+++ b/_includes/aipnums.html
@@ -1,4 +1,15 @@
-{% assign aips=include.aips|split:"," %}
+{% assign aips = include.aips | split:"," %}
 {% for aipnum in aips %}
-  <a href="{{ '/' | relative_url }}{{aipnum|strip|prepend:'aip-'}}/">{{aipnum|strip}}</a>{% if forloop.last == false %}, {% endif %}
+  {% assign aipnum_stripped = aipnum | strip %}
+  {% assign aip_href = nil %}
+  {% for aip_page in site.pages %}
+    {% if aip_page.aip %}
+      {% assign aip_page_num = aip_page.aip | append: '' %}
+      {% if aip_page_num == aipnum_stripped %}
+        {% assign aip_href = aip_page.url | relative_url %}
+        {% break %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+  <a href="{% if aip_href %}{{ aip_href }}{% else %}{{ '/AIPS/aip-' | append: aipnum_stripped | relative_url }}{% endif %}">{{ aipnum_stripped }}</a>{% if forloop.last == false %}, {% endif %}
 {% endfor %}

--- a/_includes/aiptable.html
+++ b/_includes/aiptable.html
@@ -1,5 +1,5 @@
 {% for status in site.data.statuses %}
-  {% assign aips = include.aips|where:"status",status|sort:"aip" %}
+  {% assign aips = include.aips | where:"status", status | where_exp:"page", "page.aip != '<to be assigned>'" | sort:"aip" %}
   {% assign count = aips|size %}
   {% if count > 0 %}
     <h2>{{status}}</h2>

--- a/_layouts/aip.html
+++ b/_layouts/aip.html
@@ -53,6 +53,12 @@ layout: default
       <td>{% include aipnums.html aips=page.requires %}</td>
     </tr>
     {% endif %}
+    {% if page.extends != undefined %}
+    <tr>
+      <th>Extends</th>
+      <td>{% include aipnums.html aips=page.extends %}</td>
+    </tr>
+    {% endif %}
     {% if page.replaces != undefined %}
     <tr>
       <th>Replaces</th>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,7 +1,7 @@
 ---
 ---
 
-@import "{{ site.theme }}";
+@use "minima";
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap');
 
 // ADAMANT-aligned palette: clean, minimal, professional


### PR DESCRIPTION
## Description

Adds a draft Standard Core AIP for optional transaction `timestampMs` support.

The draft covers activation, validation, serialization stability, API/socket exposure, sorting behavior, backwards compatibility, and test requirements.

Additionally, this branch also:
- updates `.gitignore` with additional code editor artifacts
- switches AIP `extends` references to numeric values and improves the AIP table layout
- refreshes Jekyll dependencies and local setup docs, and adjusts `_config.yml` and `assets/main.scss` for the current build/theme setup

## Related

- Node issue: Adamant-im/adamant#209
- Initial node implementation: Adamant-im/adamant#93
- Completion PR: Adamant-im/adamant#210
