### PR TITLE
chore: use generated AIP page URLs in home page notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ In VS Code, this workspace disables built-in SCSS validation because Jekyll entr
 
 The published site is deployed to GitHub Pages for the [Adamant-im/AIPs](https://github.com/Adamant-im/AIPs) repository and served on the custom domain `https://aips.adamant.im` configured in [CNAME](CNAME).
 
+Generated AIP pages currently resolve under paths such as `https://aips.adamant.im/AIPS/aip-21`. When linking to AIP pages from Jekyll templates, prefer each page's generated `page.url` instead of hardcoding `/aip-N` paths.
+
 GitHub Pages is configured to publish from the `master` branch. The settings page itself is not publicly readable without repository access, so this README documents the verified public deployment target, branch, and local build process.
 
 ## Contributing

--- a/index.html
+++ b/index.html
@@ -3,11 +3,19 @@ layout: default
 title: Home
 ---
 
+{% assign aip_1_href = '/AIPS/aip-1' | relative_url %}
+{% for aip_page in site.pages %}
+  {% if aip_page.aip == 1 or aip_page.aip == '1' %}
+    {% assign aip_1_href = aip_page.url | relative_url %}
+    {% break %}
+  {% endif %}
+{% endfor %}
+
 <h1 class="page-heading">AIPs </h1>
 <p>ADAMANT Improvement Proposals (AIPs) describe standards for the ADAMANT Messenger platform, including core protocol specifications, and client APIs.</p>
 
 <h2>Contributing</h2>
-<p>First review <a href="{{ '/aip-1/' | relative_url }}">AIP-1</a>. Then clone the repository and add your AIP to it. There is a <a href="https://github.com/Adamant-im/AIPs/blob/master/aip-X.md">template AIP here</a>. Then submit a Pull Request to ADAMANT's <a href="https://github.com/Adamant-im/AIPs">AIPs repository</a>.</p>
+<p>First review <a href="{{ aip_1_href }}">AIP-1</a>. Then clone the repository and add your AIP to it. There is a <a href="https://github.com/Adamant-im/AIPs/blob/master/aip-X.md">template AIP here</a>. Then submit a Pull Request to ADAMANT's <a href="https://github.com/Adamant-im/AIPs">AIPs repository</a>.</p>
 
 <h2>AIP status terms</h2>
 <ul>


### PR DESCRIPTION
## Summary
- update the home page AIP-1 link to resolve from the generated page URL instead of a hardcoded `/aip-1/` path
- document in the README that generated AIP pages currently publish under `/AIPS/aip-N`
- keep template link guidance aligned with the actual GitHub Pages output paths

## Testing
- bundle exec jekyll build